### PR TITLE
Fix deprecations and cleanup frontend

### DIFF
--- a/lib/screens/choose_join_method_screen.dart
+++ b/lib/screens/choose_join_method_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/app_colors.dart';
 import 'join_event_qr_screen.dart';
 import 'join_event_code_screen.dart';
 import '../widgets/section_header.dart';
@@ -11,12 +12,12 @@ class ChooseJoinMethodScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color.fromARGB(255, 34, 21, 53),
+      backgroundColor: AppColors.primaryBackground,
       appBar: AppBar(
         automaticallyImplyLeading: false,
         title: const SectionHeader("Event beitreten"),
-        backgroundColor: const Color.fromARGB(255, 34, 21, 53),
-        foregroundColor: const Color.fromARGB(255, 221, 115, 45),
+        backgroundColor: AppColors.primaryBackground,
+        foregroundColor: AppColors.accent,
       ),
       body: Padding(
         padding: const EdgeInsets.all(24.0),
@@ -26,7 +27,7 @@ class ChooseJoinMethodScreen extends StatelessWidget {
           children: [
             ElevatedButton.icon(
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color.fromARGB(255, 221, 115, 45),
+                backgroundColor: AppColors.accent,
                 padding: const EdgeInsets.symmetric(vertical: 30),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),

--- a/lib/screens/evaluation_screen.dart
+++ b/lib/screens/evaluation_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:prompt_master/screens/xp_reward_screen.dart';
 import 'package:prompt_master/utils/app_colors.dart';
 import 'package:prompt_master/utils/xp_logic.dart';
+import 'dart:developer' as developer;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/user_service.dart';
 import '../services/task_service.dart';
@@ -52,10 +53,10 @@ class _EvaluationScreenState extends State<EvaluationScreen> {
           stars: widget.score,
         );
       } else {
-        print("⚠️ Kein user_id gefunden");
+        developer.log('Kein user_id gefunden', name: 'EvaluationScreen');
       }
     } catch (e) {
-      print("❌ Fehler bei XP-Vergabe: $e");
+      developer.log('Fehler bei XP-Vergabe: $e', name: 'EvaluationScreen');
     }
   }
 
@@ -219,6 +220,7 @@ class _EvaluationScreenState extends State<EvaluationScreen> {
                     onPressed: () async {
                       try {
                         await TaskService.markAsDone(widget.taskId);
+                        if (!mounted) return;
 
                         // Beispielwerte: hole echte Daten aus Backend oder local state
                         final xp = XPLogic.calculateTotalXP(
@@ -226,6 +228,7 @@ class _EvaluationScreenState extends State<EvaluationScreen> {
                           widget.score,
                         );
                         final prefs = await SharedPreferences.getInstance();
+                        if (!mounted) return;
                         final userXP = prefs.getInt('xp') ?? 0;
                         final newXP = userXP + xp;
                         final level = prefs.getInt('level') ?? 1;

--- a/lib/screens/join_event_code_screen.dart
+++ b/lib/screens/join_event_code_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/app_colors.dart';
 import '../widgets/section_header.dart';
 
 
@@ -38,12 +39,12 @@ class _JoinEventCodeScreenState extends State<JoinEventCodeScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color.fromARGB(255, 34, 21, 53),
+      backgroundColor: AppColors.primaryBackground,
       appBar: AppBar(
         automaticallyImplyLeading: false,
         title: const SectionHeader("Code eingeben"),
-        backgroundColor: const Color.fromARGB(255, 34, 21, 53),
-        foregroundColor: const Color.fromARGB(255, 221, 115, 45),
+        backgroundColor: AppColors.primaryBackground,
+        foregroundColor: AppColors.accent,
       ),
       body: Padding(
         padding: const EdgeInsets.all(24),
@@ -57,12 +58,12 @@ class _JoinEventCodeScreenState extends State<JoinEventCodeScreen> {
               children: [
                 const Text(
                   "Gib deinen Event-Code ein:",
-                  style: TextStyle(fontSize: 18, color: Colors.white),
+                  style: TextStyle(fontSize: 18, color: AppColors.white),
                 ),
                 const SizedBox(height: 16),
                 TextField(
                   controller: _codeController,
-                  style: const TextStyle(color: Colors.white),
+                  style: const TextStyle(color: AppColors.white),
                   decoration: InputDecoration(
                     filled: true,
                     fillColor: Colors.white10,
@@ -86,7 +87,7 @@ class _JoinEventCodeScreenState extends State<JoinEventCodeScreen> {
             ElevatedButton(
               onPressed: _joinEvent,
               style: ElevatedButton.styleFrom(
-                backgroundColor: const Color.fromARGB(255, 221, 115, 45),
+                backgroundColor: AppColors.accent,
                 padding: const EdgeInsets.symmetric(vertical: 16),
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(12),

--- a/lib/screens/join_event_qr_screen.dart
+++ b/lib/screens/join_event_qr_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:mobile_scanner/mobile_scanner.dart';
+import '../utils/app_colors.dart';
 import '../widgets/section_header.dart';
 
 
@@ -17,12 +18,12 @@ class _JoinEventQRScreenState extends State<JoinEventQRScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: const Color.fromARGB(255, 34, 21, 53),
+      backgroundColor: AppColors.primaryBackground,
       appBar: AppBar(
         automaticallyImplyLeading: false,
         title: const SectionHeader("QR-Code scannen"),
-        backgroundColor: const Color.fromARGB(255, 34, 21, 53),
-        foregroundColor: const Color.fromARGB(255, 221, 115, 45),
+        backgroundColor: AppColors.primaryBackground,
+        foregroundColor: AppColors.accent,
       ),
       body: Stack(
         children: [
@@ -40,6 +41,7 @@ class _JoinEventQRScreenState extends State<JoinEventQRScreen> {
 
                   // Beispiel: automatisch zurück zur vorherigen Seite
                   Future.delayed(const Duration(milliseconds: 500), () {
+                    if (!mounted) return;
                     Navigator.pop(context);
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(content: Text("Beigetreten zu: $code")),

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -9,10 +9,10 @@ class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
 
   @override
-  _LoginScreenState createState() => _LoginScreenState();
+  LoginScreenState createState() => LoginScreenState();
 }
 
-class _LoginScreenState extends State<LoginScreen> {
+class LoginScreenState extends State<LoginScreen> {
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
   final TextEditingController usernameController =
@@ -42,6 +42,7 @@ class _LoginScreenState extends State<LoginScreen> {
           isLoginMode
               ? await AuthService.login(email, password)
               : await AuthService.register(email, password, username); // NEU
+      if (!mounted) return;
 
       if (response.statusCode == 200) {
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/profile_screen.dart
+++ b/lib/screens/profile_screen.dart
@@ -58,7 +58,7 @@ class _ProfileScreenState extends State<ProfileScreen>
           style: const TextStyle(
             fontWeight: FontWeight.bold,
             fontSize: 32,
-            color: Color.fromARGB(255, 221, 115, 45),
+            color: AppColors.accent,
           ),
         ),
         backgroundColor: AppColors.primaryBackground,

--- a/lib/screens/profile_tab_content.dart
+++ b/lib/screens/profile_tab_content.dart
@@ -29,7 +29,7 @@ class _ProfileTabContentState extends State<ProfileTabContent> {
           return Center(
             child: Text(
               "Fehler: ${snapshot.error}",
-              style: const TextStyle(color: Colors.white),
+              style: const TextStyle(color: AppColors.white),
             ),
           );
         } else {
@@ -51,7 +51,7 @@ class _ProfileTabContentState extends State<ProfileTabContent> {
                   child: const Icon(
                     Icons.person,
                     size: 50,
-                    color: Colors.white,
+                    color: AppColors.white,
                   ),
                 ),
                 const SizedBox(height: 16),
@@ -59,7 +59,7 @@ class _ProfileTabContentState extends State<ProfileTabContent> {
                   username,
                   style: const TextStyle(
                     fontSize: 24,
-                    color: Colors.white,
+                    color: AppColors.white,
                     fontWeight: FontWeight.bold,
                   ),
                 ),
@@ -84,7 +84,7 @@ class _ProfileTabContentState extends State<ProfileTabContent> {
         title: Text(title, style: const TextStyle(color: Colors.white70)),
         trailing: Text(
           value,
-          style: const TextStyle(color: Colors.white, fontSize: 16),
+          style: const TextStyle(color: AppColors.white, fontSize: 16),
         ),
       ),
     );

--- a/lib/screens/scoreboard_screen.dart
+++ b/lib/screens/scoreboard_screen.dart
@@ -59,7 +59,7 @@ class _ScoreboardScreenState extends State<ScoreboardScreen> {
                   decoration: BoxDecoration(
                     color: Colors.white10,
                     borderRadius: BorderRadius.circular(12),
-                    border: Border.all(color: Colors.white24),
+                    border: Border.all(color: AppColors.divider),
                   ),
                   child: Row(
                     children: [
@@ -68,7 +68,7 @@ class _ScoreboardScreenState extends State<ScoreboardScreen> {
                         style: const TextStyle(
                           fontSize: 24,
                           fontWeight: FontWeight.bold,
-                          color: Colors.white,
+                          color: AppColors.white,
                         ),
                       ),
                       const SizedBox(width: 16),
@@ -81,7 +81,7 @@ class _ScoreboardScreenState extends State<ScoreboardScreen> {
                               style: const TextStyle(
                                 fontSize: 16,
                                 fontWeight: FontWeight.bold,
-                                color: Colors.white,
+                                color: AppColors.white,
                               ),
                             ),
                             const SizedBox(height: 4),

--- a/lib/screens/task_screen.dart
+++ b/lib/screens/task_screen.dart
@@ -108,6 +108,7 @@ class _TaskScreenState extends State<TaskScreen> {
                               prompt,
                               widget.taskId,
                             );
+                            if (!mounted) return;
 
                             setState(() {
                               isLoading = false;

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'dart:developer' as developer;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'config.dart';
 
@@ -13,7 +14,7 @@ class AIService {
     final userId = prefs.getString('user_id');
 
     if (userId == null) {
-      print("❌ Kein User angemeldet");
+      developer.log('Kein User angemeldet', name: 'AIService');
       return null;
     }
 
@@ -31,8 +32,8 @@ class AIService {
         }),
       );
 
-      print("🔁 Bewertung senden: ${response.statusCode}");
-      print("🔁 Antworttext: ${response.body}");
+      developer.log('Bewertung senden: ${response.statusCode}', name: 'AIService');
+      developer.log('Antworttext: ${response.body}', name: 'AIService');
 
       if (response.statusCode == 200) {
         return jsonDecode(response.body);
@@ -40,7 +41,7 @@ class AIService {
         return null;
       }
     } catch (e) {
-      print('❌ Netzwerkfehler: $e');
+      developer.log('Netzwerkfehler: $e', name: 'AIService');
       return null;
     }
   }

--- a/lib/services/task_service.dart
+++ b/lib/services/task_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'dart:developer' as developer;
 import 'config.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -16,8 +17,8 @@ class TaskService {
 
     final response = await http.get(url);
 
-    print('📡 GET: $url');
-    print('🔁 Antwort: ${response.statusCode} – ${response.body}');
+    developer.log('GET: $url', name: 'TaskService');
+    developer.log('Antwort: ${response.statusCode} – ${response.body}', name: 'TaskService');
 
     if (response.statusCode == 200) {
       final List<dynamic> data = jsonDecode(response.body);
@@ -38,12 +39,12 @@ class TaskService {
 
     final url = Uri.parse('${Config.baseUrl}/user/$userId/task/$taskId/done');
 
-    print('🔁 Aufgabe erledigt markieren: $url');
+    developer.log('Aufgabe erledigt markieren: $url', name: 'TaskService');
 
     final response = await http.post(url);
 
-    print('🔁 Antwortstatus: ${response.statusCode}');
-    print('🔁 Antworttext: ${response.body}');
+    developer.log('Antwortstatus: ${response.statusCode}', name: 'TaskService');
+    developer.log('Antworttext: ${response.body}', name: 'TaskService');
 
     if (response.statusCode != 200) {
       throw Exception(

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
+import 'dart:developer' as developer;
 import 'package:prompt_master/utils/xp_logic.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'config.dart';
@@ -105,6 +106,6 @@ class UserService {
       throw Exception('XP konnte nicht gesendet werden: ${response.body}');
     }
 
-    print('✅ $xp XP erfolgreich gesendet.');
+    developer.log('XP erfolgreich gesendet: $xp', name: 'UserService');
   }
 }

--- a/lib/widgets/MainNavigation
+++ b/lib/widgets/MainNavigation
@@ -1,3 +1,6 @@
+import 'package:flutter/material.dart';
+import '../utils/app_colors.dart';
+
 class MainNavigation extends StatefulWidget {
   const MainNavigation({super.key});
 
@@ -20,7 +23,7 @@ class _MainNavigationState extends State<MainNavigation> {
     return Scaffold(
       body: _pages[_currentIndex],
       bottomNavigationBar: BottomNavigationBar(
-        backgroundColor: const Color.fromARGB(255, 58, 13, 136),
+        backgroundColor: AppColors.bottomNavBar,
         currentIndex: _currentIndex,
         onTap: (index) => setState(() => _currentIndex = index),
         items: const [

--- a/lib/widgets/inline_title.dart
+++ b/lib/widgets/inline_title.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/app_colors.dart';
 
 class InlineTitle extends StatelessWidget {
   final String text;
@@ -13,7 +14,7 @@ class InlineTitle extends StatelessWidget {
       style: const TextStyle(
         fontSize: 22,
         fontWeight: FontWeight.bold,
-        color: Color.fromARGB(255, 221, 115, 45),
+        color: AppColors.accent,
       ),
     );
   }

--- a/lib/widgets/section_header.dart
+++ b/lib/widgets/section_header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/app_colors.dart';
 
 class SectionHeader extends StatelessWidget {
   final String text;
@@ -10,10 +11,10 @@ class SectionHeader extends StatelessWidget {
     return Text(
       text,
       style: const TextStyle(
-        backgroundColor: Color.fromARGB(255, 34, 21, 53),
+        backgroundColor: AppColors.primaryBackground,
         fontWeight: FontWeight.bold,
         fontSize: 40,
-        color: Color.fromARGB(255, 221, 115, 45),
+        color: AppColors.accent,
       ),
     );
   }

--- a/lib/widgets/task_card.dart
+++ b/lib/widgets/task_card.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../utils/app_colors.dart';
 
 class TaskCard extends StatelessWidget {
   final String title;
@@ -41,7 +42,7 @@ class TaskCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Card(
-      color: const Color.fromARGB(255, 221, 115, 45),
+      color: AppColors.accent,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
       margin: const EdgeInsets.symmetric(vertical: 8),
       elevation: 4,
@@ -60,16 +61,16 @@ class TaskCard extends StatelessWidget {
           style: const TextStyle(
             fontSize: 20,
             fontWeight: FontWeight.bold,
-            color: Colors.white,
+            color: AppColors.white,
           ),
         ),
         subtitle: Text(
           title,
-          style: const TextStyle(color: Colors.white),
+          style: const TextStyle(color: AppColors.white),
           maxLines: 1,
           overflow: TextOverflow.ellipsis,
         ),
-        trailing: const Icon(Icons.arrow_forward_ios, color: Colors.white),
+        trailing: const Icon(Icons.arrow_forward_ios, color: AppColors.white),
         onTap: onTap,
       ),
     );


### PR DESCRIPTION
## Summary
- remove `print` statements and use `developer.log`
- add `mounted` checks in async callbacks
- make login screen state class public
- pull colors from `AppColors`

## Testing
- `dart format -o none -l 120 lib` *(fails: dart not installed)*
- `flutter --version` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684adbfe9cb083209b64927ab246a47f