### PR TITLE
Add badge grid view and service

### DIFF
--- a/lib/screens/badges_tab_content.dart
+++ b/lib/screens/badges_tab_content.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:prompt_master/utils/app_colors.dart';
-import 'package:prompt_master/services/user_service.dart';
+import 'package:prompt_master/services/badge_service.dart';
 import 'package:prompt_master/models/badge.dart' as model;
-import 'package:prompt_master/widgets/badge_tile.dart';
+import 'package:prompt_master/widgets/badge_grid.dart';
 
 class BadgesTabContent extends StatefulWidget {
   const BadgesTabContent({super.key});
@@ -17,7 +17,7 @@ class _BadgesTabContentState extends State<BadgesTabContent> {
   @override
   void initState() {
     super.initState();
-    _badgesFuture = UserService.fetchUserBadges();
+    _badgesFuture = BadgeService.fetchCurrentUserBadges();
   }
 
   @override
@@ -46,17 +46,7 @@ class _BadgesTabContentState extends State<BadgesTabContent> {
             );
           }
 
-          return ListView.builder(
-            padding: const EdgeInsets.all(16),
-            itemCount: badges.length,
-            itemBuilder: (context, index) {
-              final badge = badges[index];
-              return Card(
-                color: AppColors.accent.withAlpha(26),
-                child: BadgeTile(badge: badge),
-              );
-            },
-          );
+          return BadgeGrid(badges: badges);
         }
       },
     );

--- a/lib/screens/xp_reward_screen.dart
+++ b/lib/screens/xp_reward_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:prompt_master/utils/app_colors.dart';
+import 'package:prompt_master/services/badge_service.dart';
 
 class XPRewardScreen extends StatefulWidget {
   final int xpGained;
@@ -44,6 +45,22 @@ class _XPRewardScreenState extends State<XPRewardScreen>
     ).animate(CurvedAnimation(parent: _controller, curve: Curves.easeInOut));
 
     _controller.forward();
+
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _showNewBadgeInfo();
+    });
+  }
+
+  Future<void> _showNewBadgeInfo() async {
+    final newBadges = await BadgeService.checkForNewBadges();
+    if (!mounted || newBadges.isEmpty) return;
+    for (final badge in newBadges) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('🎉 Du hast das Badge "${badge.title}" freigeschaltet!'),
+        ),
+      );
+    }
   }
 
   @override

--- a/lib/services/badge_service.dart
+++ b/lib/services/badge_service.dart
@@ -1,0 +1,51 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+import 'config.dart';
+import 'package:prompt_master/models/badge.dart';
+
+class BadgeService {
+  static Future<List<Badge>> fetchBadges(String userId) async {
+    final response = await http.get(
+      Uri.parse('${Config.baseUrl}/user/$userId/badges'),
+    );
+
+    if (response.statusCode == 200) {
+      final List<dynamic> data = jsonDecode(response.body);
+      return data.map((e) => Badge.fromJson(e)).toList();
+    } else {
+      throw Exception('Fehler beim Abrufen der Badges: ${response.body}');
+    }
+  }
+
+  static Future<List<Badge>> fetchCurrentUserBadges() async {
+    final prefs = await SharedPreferences.getInstance();
+    final userId = prefs.getString('user_id');
+
+    if (userId == null) {
+      throw Exception('❌ Kein user_id gefunden.');
+    }
+
+    return fetchBadges(userId);
+  }
+
+  /// Prüft, ob neue Badges freigeschaltet wurden.
+  /// Gibt eine Liste neu freigeschalteter Badges zurück und
+  /// speichert diese lokal, um mehrfache Benachrichtigungen zu vermeiden.
+  static Future<List<Badge>> checkForNewBadges() async {
+    final prefs = await SharedPreferences.getInstance();
+    final known = prefs.getStringList('unlocked_badges') ?? <String>[];
+
+    final badges = await fetchCurrentUserBadges();
+    final newlyUnlocked = badges
+        .where((b) => b.awardedAt.isNotEmpty && !known.contains(b.id))
+        .toList();
+
+    if (newlyUnlocked.isNotEmpty) {
+      final updated = [...known, ...newlyUnlocked.map((b) => b.id)];
+      await prefs.setStringList('unlocked_badges', updated);
+    }
+
+    return newlyUnlocked;
+  }
+}

--- a/lib/widgets/badge_grid.dart
+++ b/lib/widgets/badge_grid.dart
@@ -1,0 +1,56 @@
+import 'package:flutter/material.dart';
+import 'package:prompt_master/models/badge.dart' as model;
+import 'package:prompt_master/utils/app_colors.dart';
+
+class BadgeGrid extends StatelessWidget {
+  final List<model.Badge> badges;
+
+  const BadgeGrid({super.key, required this.badges});
+
+  bool _isUnlocked(model.Badge badge) => badge.awardedAt.isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    return GridView.builder(
+      padding: const EdgeInsets.all(16),
+      gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 3,
+        mainAxisSpacing: 12,
+        crossAxisSpacing: 12,
+      ),
+      itemCount: badges.length,
+      itemBuilder: (context, index) {
+        final badge = badges[index];
+        return Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Opacity(
+              opacity: _isUnlocked(badge) ? 1.0 : 0.3,
+              child: Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: AppColors.accent,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Image.network(
+                  badge.iconUrl,
+                  width: 50,
+                  height: 50,
+                ),
+              ),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              badge.title,
+              textAlign: TextAlign.center,
+              style: const TextStyle(
+                fontSize: 12,
+                color: AppColors.white,
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a `BadgeService` to fetch badges from `/api/user/:id/badges`
- add `BadgeGrid` widget for displaying badge icons
- show the grid in the profile's badges tab
- notify users of newly unlocked badges in the XP reward screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685d1b14040c832082697a0bd543cff5