### PR TITLE
Refactor services to use AuthService for user id

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:percent_indicator/percent_indicator.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:prompt_master/services/user_service.dart';
 import 'package:prompt_master/services/task_service.dart';
+import 'package:prompt_master/services/auth_service.dart';
 import 'package:prompt_master/utils/app_colors.dart';
 import 'package:prompt_master/utils/xp_logic.dart';
 import '../widgets/task_card.dart';
@@ -27,14 +27,13 @@ class _DashboardScreenState extends State<DashboardScreen> {
   }
 
   Future<void> _initData() async {
-    final prefs = await SharedPreferences.getInstance();
+    final userId = await AuthService.getUserId();
     if (!mounted) return;
-    final userId = prefs.getString('user_id');
 
     if (userId != null) {
       setState(() {
         _userStats = UserService.fetchUserStats(userId);
-        _tasksFuture = TaskService.fetchTasks(userId);
+        _tasksFuture = TaskService.fetchTasks();
       });
     }
   }

--- a/lib/screens/evaluation_screen.dart
+++ b/lib/screens/evaluation_screen.dart
@@ -6,6 +6,7 @@ import 'dart:developer' as developer;
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/user_service.dart';
 import '../services/task_service.dart';
+import '../services/auth_service.dart';
 import '../widgets/section_header.dart';
 
 class EvaluationScreen extends StatefulWidget {
@@ -49,7 +50,7 @@ class _EvaluationScreenState extends State<EvaluationScreen> {
   Future<void> _updateXPAndLevel() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final userId = prefs.getString('user_id');
+      final userId = await AuthService.getUserId();
 
       if (userId == null) {
         developer.log('Kein user_id gefunden', name: 'EvaluationScreen');

--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import '../services/task_service.dart';
+import '../services/auth_service.dart';
 import '../screens/task_screen.dart';
 import '../widgets/task_card.dart';
 import '../widgets/section_header.dart';
@@ -24,13 +24,12 @@ class _TaskListScreenState extends State<TaskListScreen> {
   }
 
   Future<void> _loadTasks() async {
-    final prefs = await SharedPreferences.getInstance();
+    final userId = await AuthService.getUserId();
     if (!mounted) return;
-    final userId = prefs.getString('user_id');
 
     if (userId != null) {
       setState(() {
-        _tasksFuture = TaskService.fetchTasks(userId);
+        _tasksFuture = TaskService.fetchTasks();
       });
     }
   }

--- a/lib/services/ai_service.dart
+++ b/lib/services/ai_service.dart
@@ -1,8 +1,8 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'dart:developer' as developer;
-import 'package:shared_preferences/shared_preferences.dart';
 import 'config.dart';
+import 'auth_service.dart';
 
 class AIService {
   static Future<Map<String, dynamic>?> evaluatePrompt(
@@ -10,8 +10,7 @@ class AIService {
     String prompt,
     String taskId,
   ) async {
-    final prefs = await SharedPreferences.getInstance();
-    final userId = prefs.getString('user_id');
+    final userId = await AuthService.getUserId();
 
     if (userId == null) {
       developer.log('Kein User angemeldet', name: 'AIService');

--- a/lib/services/badge_service.dart
+++ b/lib/services/badge_service.dart
@@ -3,6 +3,7 @@ import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
 import 'config.dart';
 import 'package:prompt_master/models/badge.dart';
+import 'auth_service.dart';
 
 class BadgeService {
   static Future<List<Badge>> fetchBadges(String userId) async {
@@ -19,8 +20,7 @@ class BadgeService {
   }
 
   static Future<List<Badge>> fetchCurrentUserBadges() async {
-    final prefs = await SharedPreferences.getInstance();
-    final userId = prefs.getString('user_id');
+    final userId = await AuthService.getUserId();
 
     if (userId == null) {
       throw Exception('❌ Kein user_id gefunden.');

--- a/lib/services/task_service.dart
+++ b/lib/services/task_service.dart
@@ -2,15 +2,14 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'dart:developer' as developer;
 import 'config.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'auth_service.dart';
 
 class TaskService {
-  static Future<List<Map<String, dynamic>>> fetchTasks(String userId) async {
-    final prefs = await SharedPreferences.getInstance();
-    final userId = prefs.getString('user_id');
+  static Future<List<Map<String, dynamic>>> fetchTasks() async {
+    final userId = await AuthService.getUserId();
 
     if (userId == null) {
-      throw Exception("❌ Kein Benutzer angemeldet");
+      throw Exception('❌ Kein Benutzer angemeldet');
     }
 
     final url = Uri.parse('${Config.baseUrl}/tasks/$userId'); // ← wichtig!
@@ -30,11 +29,10 @@ class TaskService {
 
 
   static Future<void> markAsDone(String taskId) async {
-    final prefs = await SharedPreferences.getInstance();
-    final userId = prefs.getString('user_id');
+    final userId = await AuthService.getUserId();
 
     if (userId == null) {
-      throw Exception("❌ Kein Benutzer angemeldet (user_id fehlt)");
+      throw Exception('❌ Kein Benutzer angemeldet (user_id fehlt)');
     }
 
     final url = Uri.parse('${Config.baseUrl}/user/$userId/task/$taskId/done');

--- a/lib/services/user_service.dart
+++ b/lib/services/user_service.dart
@@ -4,6 +4,7 @@ import 'dart:developer' as developer;
 import 'package:prompt_master/utils/xp_logic.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'config.dart';
+import 'auth_service.dart';
 import 'package:prompt_master/models/badge.dart' as model;
 import 'badge_service.dart';
 
@@ -46,10 +47,10 @@ class UserService {
   /// Holt immer aktuelle Daten des eingeloggten Nutzers (für Profilseite)
   static Future<Map<String, dynamic>> getFreshUserStats() async {
     final prefs = await SharedPreferences.getInstance();
-    final userId = prefs.getString('user_id');
+    final userId = await AuthService.getUserId();
 
     if (userId == null) {
-      throw Exception("❌ Kein user_id in SharedPreferences gefunden.");
+      throw Exception('❌ Kein user_id gefunden.');
     }
 
     final url = Uri.parse('${Config.baseUrl}/user/$userId');
@@ -70,11 +71,10 @@ class UserService {
   }
 
   static Future<List<model.Badge>> fetchUserBadges() async {
-    final prefs = await SharedPreferences.getInstance();
-    final userId = prefs.getString('user_id');
+    final userId = await AuthService.getUserId();
 
     if (userId == null) {
-      throw Exception("❌ Kein user_id gefunden.");
+      throw Exception('❌ Kein user_id gefunden.');
     }
 
     final response = await http.get(
@@ -93,7 +93,7 @@ class UserService {
   /// (z.B. Anzahl freigeschalteter Badges und erledigter Aufgaben).
   static Future<Map<String, int>> fetchUserStatsSummary() async {
     final prefs = await SharedPreferences.getInstance();
-    final userId = prefs.getString('user_id');
+    final userId = await AuthService.getUserId();
 
     if (userId == null) {
       throw Exception('❌ Kein user_id gefunden.');


### PR DESCRIPTION
## Summary
- centralize user ID retrieval through `AuthService.getUserId`
- update dashboard, evaluation and task list screens to use the new method
- simplify `TaskService.fetchTasks` API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d818b71e88320acf7e3bd9d7099eb