### PR TITLE
Add prompt history screen

### DIFF
--- a/lib/screens/prompt_history_screen.dart
+++ b/lib/screens/prompt_history_screen.dart
@@ -1,0 +1,162 @@
+import 'package:flutter/material.dart';
+import '../utils/app_colors.dart';
+import '../widgets/section_header.dart';
+import '../services/prompt_history_service.dart';
+
+class PromptHistoryScreen extends StatefulWidget {
+  const PromptHistoryScreen({super.key});
+
+  @override
+  State<PromptHistoryScreen> createState() => _PromptHistoryScreenState();
+}
+
+class _PromptHistoryScreenState extends State<PromptHistoryScreen> {
+  late Future<List<Map<String, dynamic>>> _historyFuture;
+  List<Map<String, dynamic>> _history = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _historyFuture = PromptHistoryService.fetchPromptHistory();
+  }
+
+  String _formatDate(String iso) {
+    final date = DateTime.tryParse(iso)?.toLocal();
+    if (date == null) return iso;
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${two(date.day)}.${two(date.month)}.${date.year} ${two(date.hour)}:${two(date.minute)}';
+  }
+
+  Widget _buildStars(int count) {
+    return Row(
+      children: List.generate(5, (index) {
+        return Icon(
+          index < count ? Icons.star : Icons.star_border,
+          color: AppColors.accent,
+          size: 20,
+        );
+      }),
+    );
+  }
+
+  Future<void> _deletePrompt(String id, int index) async {
+    try {
+      await PromptHistoryService.deletePrompt(id);
+      setState(() {
+        _history.removeAt(index);
+      });
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Fehler beim Löschen: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.primaryBackground,
+      appBar: AppBar(
+        title: const SectionHeader('Prompt-Historie'),
+        backgroundColor: AppColors.primaryBackground,
+        foregroundColor: AppColors.accent,
+        elevation: 0,
+      ),
+      body: FutureBuilder<List<Map<String, dynamic>>>(
+        future: _historyFuture,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.hasError) {
+            return Center(
+              child: Text('Fehler: ${snapshot.error}'),
+            );
+          } else if (!snapshot.hasData || snapshot.data!.isEmpty) {
+            return const Center(child: Text('Keine Daten verfügbar'));
+          } else {
+            if (_history.isEmpty) {
+              _history = List<Map<String, dynamic>>.from(snapshot.data!);
+            }
+            return ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: _history.length,
+              itemBuilder: (context, index) {
+                final item = _history[index];
+                final id = item['id'] ?? item['promptId'];
+                final prompt = item['prompt'] ?? '';
+                final created = item['created_at'] ?? '';
+                final rating = item['rating'];
+                final feedback = item['feedback'];
+
+                return Dismissible(
+                  key: Key('$id'),
+                  direction: DismissDirection.endToStart,
+                  background: Container(
+                    padding: const EdgeInsets.only(right: 20),
+                    alignment: Alignment.centerRight,
+                    color: Colors.red,
+                    child: const Icon(Icons.delete, color: AppColors.white),
+                  ),
+                  onDismissed: (_) => _deletePrompt('$id', index),
+                  child: Container(
+                    margin: const EdgeInsets.only(bottom: 12),
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      color: Colors.white10,
+                      borderRadius: BorderRadius.circular(12),
+                      border: Border.all(color: AppColors.divider),
+                    ),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          prompt,
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: const TextStyle(color: AppColors.white),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          _formatDate(created),
+                          style: const TextStyle(
+                            color: AppColors.textSecondary,
+                            fontSize: 12,
+                          ),
+                        ),
+                        if (rating != null) ...[
+                          const SizedBox(height: 8),
+                          _buildStars(rating is int ? rating : int.tryParse('$rating') ?? 0),
+                        ],
+                        if (feedback != null && feedback.toString().isNotEmpty)
+                          ExpansionTile(
+                            tilePadding: EdgeInsets.zero,
+                            title: const Text(
+                              'Mehr anzeigen',
+                              style: TextStyle(color: AppColors.white),
+                            ),
+                            children: [
+                              Align(
+                                alignment: Alignment.centerLeft,
+                                child: Padding(
+                                  padding: const EdgeInsets.only(bottom: 8),
+                                  child: Text(
+                                    feedback,
+                                    style: const TextStyle(color: AppColors.white),
+                                  ),
+                                ),
+                              ),
+                            ],
+                          ),
+                      ],
+                    ),
+                  ),
+                );
+              },
+            );
+          }
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -5,6 +5,7 @@ import '../screens/task_screen.dart';
 import '../widgets/task_card.dart';
 import '../widgets/section_header.dart';
 import 'choose_join_method_screen.dart';
+import 'prompt_history_screen.dart';
 import '../utils/app_colors.dart';
 
 class TaskListScreen extends StatefulWidget {
@@ -135,6 +136,34 @@ class _TaskListScreenState extends State<TaskListScreen> {
                     context,
                     MaterialPageRoute(
                       builder: (_) => const ChooseJoinMethodScreen(),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.all(16),
+            child: SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppColors.accent,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                icon: const Icon(Icons.history, size: 30),
+                label: const Text(
+                  "Prompt-Historie",
+                  style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+                ),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (_) => const PromptHistoryScreen(),
                     ),
                   );
                 },

--- a/lib/services/prompt_history_service.dart
+++ b/lib/services/prompt_history_service.dart
@@ -1,0 +1,46 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'dart:developer' as developer;
+import 'auth_service.dart';
+import 'config.dart';
+
+class PromptHistoryService {
+  static Future<List<Map<String, dynamic>>> fetchPromptHistory() async {
+    final userId = await AuthService.getUserId();
+
+    if (userId == null) {
+      throw Exception('❌ Kein Benutzer angemeldet');
+    }
+
+    final url = Uri.parse('${Config.baseUrl}/user/$userId/prompt-history');
+    final response = await http.get(url);
+
+    developer.log('GET: $url', name: 'PromptHistoryService');
+    developer.log('Antwort: ${response.statusCode} – ${response.body}', name: 'PromptHistoryService');
+
+    if (response.statusCode == 200) {
+      final List<dynamic> data = jsonDecode(response.body);
+      return data.map((e) => e as Map<String, dynamic>).toList();
+    } else {
+      throw Exception('Fehler beim Abrufen der Prompt-Historie: ${response.body}');
+    }
+  }
+
+  static Future<void> deletePrompt(String promptId) async {
+    final userId = await AuthService.getUserId();
+
+    if (userId == null) {
+      throw Exception('❌ Kein Benutzer angemeldet');
+    }
+
+    final url = Uri.parse('${Config.baseUrl}/user/$userId/prompt-history/$promptId');
+    final response = await http.delete(url);
+
+    developer.log('DELETE: $url', name: 'PromptHistoryService');
+    developer.log('Antwort: ${response.statusCode} – ${response.body}', name: 'PromptHistoryService');
+
+    if (response.statusCode != 200) {
+      throw Exception('Fehler beim Löschen des Prompts: ${response.body}');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- create PromptHistoryService for API calls
- implement PromptHistoryScreen with list of prompts and swipe to delete
- add button to TaskListScreen to open the new screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d95cacfcc83209da2ec55f91b0fbc