### PR TITLE
Add prompt history detail screen

### DIFF
--- a/lib/screens/prompt_history_detail_screen.dart
+++ b/lib/screens/prompt_history_detail_screen.dart
@@ -1,0 +1,115 @@
+import 'package:flutter/material.dart';
+import '../utils/app_colors.dart';
+import '../widgets/section_header.dart';
+
+class PromptHistoryDetailScreen extends StatelessWidget {
+  final Map<String, dynamic> entry;
+  const PromptHistoryDetailScreen({super.key, required this.entry});
+
+  String _formatDate(String iso) {
+    final date = DateTime.tryParse(iso)?.toLocal();
+    if (date == null) return iso;
+    String two(int n) => n.toString().padLeft(2, '0');
+    return '${two(date.day)}.${two(date.month)}.${date.year} ${two(date.hour)}:${two(date.minute)}';
+  }
+
+  Widget _buildStars(int count) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: List.generate(5, (index) {
+        return Icon(
+          index < count ? Icons.star : Icons.star_border,
+          color: AppColors.accent,
+          size: 32,
+        );
+      }),
+    );
+  }
+
+  Widget _sectionTitle(String text) {
+    return Text(
+      text,
+      style: const TextStyle(
+        fontWeight: FontWeight.bold,
+        fontSize: 18,
+        color: AppColors.accent,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final title = entry['title'] ?? 'Aufgabe';
+    final description = entry['description'] ?? '';
+    final difficulty = entry['difficulty']?.toString() ?? '';
+    final type = entry['type'] ?? '';
+    final created = entry['created_at'] ?? '';
+    final content = entry['content'] ?? '';
+    final score = entry['score'];
+    final feedback = entry['feedback'];
+    final keywordHits = entry['keyword_hits'];
+
+    return Scaffold(
+      backgroundColor: AppColors.primaryBackground,
+      appBar: AppBar(
+        title: const SectionHeader('Prompt Details'),
+        backgroundColor: AppColors.primaryBackground,
+        foregroundColor: AppColors.accent,
+        elevation: 0,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (score != null) ...[
+              Center(
+                child: _buildStars(
+                  score is int ? score : int.tryParse('$score') ?? 0,
+                ),
+              ),
+              const SizedBox(height: 20),
+            ],
+            _sectionTitle('Titel der Aufgabe:'),
+            const SizedBox(height: 8),
+            Text(title, style: const TextStyle(color: AppColors.white)),
+            const SizedBox(height: 20),
+            _sectionTitle('Aufgabenbeschreibung:'),
+            const SizedBox(height: 8),
+            Text(description, style: const TextStyle(color: AppColors.white)),
+            const SizedBox(height: 20),
+            _sectionTitle('Schwierigkeit:'),
+            const SizedBox(height: 8),
+            Text(difficulty, style: const TextStyle(color: AppColors.white)),
+            const SizedBox(height: 20),
+            _sectionTitle('Typ:'),
+            const SizedBox(height: 8),
+            Text(type, style: const TextStyle(color: AppColors.white)),
+            const SizedBox(height: 20),
+            _sectionTitle('Datum:'),
+            const SizedBox(height: 8),
+            Text(_formatDate(created),
+                style: const TextStyle(color: AppColors.white)),
+            const SizedBox(height: 20),
+            _sectionTitle('Der eingegebene Prompt:'),
+            const SizedBox(height: 8),
+            Text(content, style: const TextStyle(color: AppColors.white)),
+            const SizedBox(height: 20),
+            if (feedback != null && feedback.toString().trim().isNotEmpty) ...[
+              _sectionTitle('Feedback:'),
+              const SizedBox(height: 8),
+              Text('$feedback', style: const TextStyle(color: AppColors.white)),
+              const SizedBox(height: 20),
+            ],
+            if (keywordHits != null && keywordHits.toString().isNotEmpty) ...[
+              _sectionTitle('Keyword Treffer:'),
+              const SizedBox(height: 8),
+              Text('$keywordHits',
+                  style: const TextStyle(color: AppColors.white)),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/prompt_history_screen.dart
+++ b/lib/screens/prompt_history_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../utils/app_colors.dart';
 import '../widgets/section_header.dart';
 import '../services/prompt_history_service.dart';
+import 'prompt_history_detail_screen.dart';
 
 class PromptHistoryScreen extends StatefulWidget {
   const PromptHistoryScreen({super.key});
@@ -27,18 +28,6 @@ class _PromptHistoryScreenState extends State<PromptHistoryScreen> {
     return '${two(date.day)}.${two(date.month)}.${date.year} ${two(date.hour)}:${two(date.minute)}';
   }
 
-  Widget _buildStars(int count) {
-    return Row(
-      children: List.generate(5, (index) {
-        return Icon(
-          index < count ? Icons.star : Icons.star_border,
-          color: AppColors.accent,
-          size: 20,
-        );
-      }),
-    );
-  }
-
   Future<void> _deletePrompt(String id, int index) async {
     try {
       await PromptHistoryService.deletePrompt(id);
@@ -47,9 +36,8 @@ class _PromptHistoryScreenState extends State<PromptHistoryScreen> {
       });
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text('Fehler beim Löschen: $e')));
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Fehler beim Löschen: $e')));
     }
   }
 
@@ -95,11 +83,8 @@ class _PromptHistoryScreenState extends State<PromptHistoryScreen> {
               itemBuilder: (context, index) {
                 final item = _history[index];
                 final id = item['id'] ?? item['promptId'];
-                final prompt = item['content'] ?? 'Kein Inhalt';
+                final title = item['title'] ?? 'Prompt';
                 final created = item['created_at'] ?? '';
-                final score = item['score'];
-                final feedback = item['feedback'];
-                final keywords = item['keyword_hits'];
 
                 return Dismissible(
                   key: Key('$id'),
@@ -111,89 +96,45 @@ class _PromptHistoryScreenState extends State<PromptHistoryScreen> {
                     child: const Icon(Icons.delete, color: AppColors.white),
                   ),
                   onDismissed: (_) => _deletePrompt('$id', index),
-                  child: Container(
-                    margin: const EdgeInsets.only(bottom: 12),
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: Colors.white10,
-                      borderRadius: BorderRadius.circular(12),
-                      border: Border.all(color: AppColors.divider),
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        /// 📝 Prompt Text
-                        Text(
-                          prompt,
-                          maxLines: 3,
-                          overflow: TextOverflow.ellipsis,
-                          style: const TextStyle(
-                            color: AppColors.white,
-                            fontSize: 16,
-                            fontWeight: FontWeight.w500,
-                          ),
+                  child: GestureDetector(
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => PromptHistoryDetailScreen(entry: item),
                         ),
-
-                        const SizedBox(height: 8),
-
-                        /// 📅 Datum
-                        Text(
-                          _formatDate(created),
-                          style: const TextStyle(
-                            color: AppColors.textSecondary,
-                            fontSize: 12,
-                          ),
-                        ),
-
-                        /// ⭐ Bewertung
-                        if (score != null) ...[
-                          const SizedBox(height: 8),
-                          _buildStars(
-                            score is int ? score : int.tryParse('$score') ?? 0,
-                          ),
-                        ],
-
-                        /// 🔑 Keyword-Hits
-                        if (keywords != null &&
-                            keywords.toString().isNotEmpty) ...[
-                          const SizedBox(height: 6),
+                      );
+                    },
+                    child: Container(
+                      width: double.infinity,
+                      margin: const EdgeInsets.only(bottom: 12),
+                      padding: const EdgeInsets.all(16),
+                      decoration: BoxDecoration(
+                        color: Colors.white10,
+                        borderRadius: BorderRadius.circular(12),
+                        border: Border.all(color: AppColors.divider),
+                      ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
                           Text(
-                            'Keyword Treffer: ${keywords.toString()}',
+                            title,
+                            style: const TextStyle(
+                              color: AppColors.white,
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            _formatDate(created),
                             style: const TextStyle(
                               color: AppColors.textSecondary,
                               fontSize: 12,
                             ),
                           ),
                         ],
-
-                        /// 🗒️ Feedback
-                        if (feedback != null &&
-                            feedback.toString().trim().isNotEmpty)
-                          ExpansionTile(
-                            tilePadding: EdgeInsets.zero,
-                            collapsedIconColor: AppColors.accent,
-                            iconColor: AppColors.accent,
-                            title: const Text(
-                              'Mehr anzeigen',
-                              style: TextStyle(color: AppColors.accent),
-                            ),
-                            children: [
-                              Align(
-                                alignment: Alignment.centerLeft,
-                                child: Padding(
-                                  padding: const EdgeInsets.only(bottom: 8),
-                                  child: Text(
-                                    feedback,
-                                    style: const TextStyle(
-                                      color: AppColors.white,
-                                      fontSize: 14,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            ],
-                          ),
-                      ],
+                      ),
                     ),
                   ),
                 );


### PR DESCRIPTION
## Summary
- implement a new `PromptHistoryDetailScreen`
- refactor `PromptHistoryScreen` to show entries as tappable list

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d9c70a94c8320b633050af7247694