### PR TITLE
Add premium task generation button

### DIFF
--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -82,19 +82,35 @@ class _TaskListScreenState extends State<TaskListScreen> {
         actions: [
           if (_isPremiumUser)
             IconButton(
+              tooltip: "Neue Challenge generieren",
               onPressed: _isGenerating ? null : _generateTask,
-              tooltip: 'Neue Challenge generieren',
-              icon: _isGenerating
-                  ? const SizedBox(
-                      width: 24,
-                      height: 24,
-                      child: CircularProgressIndicator(
-                        color: AppColors.accent,
-                        strokeWidth: 2,
-                      ),
-                    )
-                  : const Icon(Icons.add_circle_outline),
-            ),
+              icon: Container(
+                padding: const EdgeInsets.all(6),
+                decoration: BoxDecoration(
+                  color: AppColors.accent,
+                  borderRadius: BorderRadius.circular(50),
+                ),
+                child:
+                    _isGenerating
+                        ? const SizedBox(
+                          width: 18,
+                          height: 18,
+                          child: CircularProgressIndicator(
+                            color: Colors.white,
+                            strokeWidth: 2,
+                          ),
+                        )
+                        : const Icon(Icons.add, color: Colors.white),
+              ),
+            )
+          else
+            IconButton(
+              tooltip: "Neue Challenge (nur für Premium)",
+              icon: const Icon(Icons.add_circle_outline),
+              onPressed: () {
+                showPremiumRequiredDialog(context);
+              },
+            )
         ],
       ),
       body: Column(

--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -19,11 +19,14 @@ class TaskListScreen extends StatefulWidget {
 
 class _TaskListScreenState extends State<TaskListScreen> {
   Future<List<Map<String, dynamic>>>? _tasksFuture;
+  bool _isPremiumUser = false;
+  bool _isGenerating = false;
 
   @override
   void initState() {
     super.initState();
     _loadTasks();
+    _checkPremium();
   }
 
   Future<void> _loadTasks() async {
@@ -37,6 +40,36 @@ class _TaskListScreenState extends State<TaskListScreen> {
     }
   }
 
+  Future<void> _checkPremium() async {
+    final premium = await UserService.isPremiumUser();
+    if (!mounted) return;
+    setState(() {
+      _isPremiumUser = premium;
+    });
+  }
+
+  Future<void> _generateTask() async {
+    setState(() {
+      _isGenerating = true;
+    });
+
+    try {
+      await TaskService.generateNewTask();
+      await _loadTasks();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('❌ $e')),
+      );
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isGenerating = false;
+        });
+      }
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -46,6 +79,23 @@ class _TaskListScreenState extends State<TaskListScreen> {
         backgroundColor: AppColors.primaryBackground,
         foregroundColor: AppColors.accent,
         elevation: 0,
+        actions: [
+          if (_isPremiumUser)
+            IconButton(
+              onPressed: _isGenerating ? null : _generateTask,
+              tooltip: 'Neue Challenge generieren',
+              icon: _isGenerating
+                  ? const SizedBox(
+                      width: 24,
+                      height: 24,
+                      child: CircularProgressIndicator(
+                        color: AppColors.accent,
+                        strokeWidth: 2,
+                      ),
+                    )
+                  : const Icon(Icons.add_circle_outline),
+            ),
+        ],
       ),
       body: Column(
         children: [

--- a/lib/services/task_service.dart
+++ b/lib/services/task_service.dart
@@ -50,4 +50,37 @@ class TaskService {
       );
     }
   }
+
+  /// Erstellt eine neue KI-generierte Aufgabe für den aktuellen Nutzer
+  static Future<Map<String, dynamic>> generateNewTask() async {
+    final userId = await AuthService.getUserId();
+    final token = await AuthService.getToken();
+
+    if (userId == null || token == null) {
+      throw Exception('❌ Kein userId oder Token.');
+    }
+
+    final url = Uri.parse('${Config.baseUrl}/user/$userId/task/generate');
+
+    developer.log('Neue Aufgabe generieren: POST $url', name: 'TaskService');
+
+    final response = await http.post(
+      url,
+      headers: {'Authorization': 'Bearer $token'},
+    );
+
+    developer.log(
+      'Antwortstatus: ${response.statusCode}',
+      name: 'TaskService',
+    );
+    developer.log('Antworttext: ${response.body}', name: 'TaskService');
+
+    if (response.statusCode == 200 || response.statusCode == 201) {
+      return jsonDecode(response.body) as Map<String, dynamic>;
+    } else {
+      throw Exception(
+        '❌ Fehler beim Generieren der Aufgabe: ${response.body}',
+      );
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- allow premium users to generate a new AI challenge from the task list
- update TaskService with `generateNewTask` API call

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e8aa62a4c83209e408d06bd1d8894