### PR TITLE
Replace SnackBars with modal dialogs

### DIFF
--- a/lib/screens/evaluation_screen.dart
+++ b/lib/screens/evaluation_screen.dart
@@ -8,7 +8,8 @@ import '../services/user_service.dart';
 import '../services/task_service.dart';
 import '../widgets/section_header.dart';
 import '../services/auth_service.dart';
-import '../utils/premium_required_dialog.dart'; 
+import '../utils/premium_required_dialog.dart';
+import '../utils/custom_dialog.dart';
 
 class EvaluationScreen extends StatefulWidget {
   final int score;
@@ -324,8 +325,10 @@ class _EvaluationScreenState extends State<EvaluationScreen> {
                           ),
                         );
                       } catch (e) {
-                        ScaffoldMessenger.of(context).showSnackBar(
-                          SnackBar(content: Text('Fehler beim Markieren: $e')),
+                        showErrorDialog(
+                          context,
+                          'Fehler',
+                          'Fehler beim Markieren: $e',
                         );
                       }
                     },

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -132,7 +132,7 @@ class _LoginScreenState extends State<LoginScreen> {
             showSuccessDialog(
               context,
               'Registriert',
-              'Registrierung erfolgreich. Bitte einloggen.',
+              'Registrierung erfolgreich. Bitte E-Mail bestätigen zum einloggen.',
             );
             setState(() {
               isLoginMode = true;

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:email_validator/email_validator.dart';
 import 'main_navigation.dart';
 import './/utils/app_colors.dart';
+import '../utils/custom_dialog.dart';
 import './/services/auth_service.dart';
 import 'forgot_password_screen.dart';
 
@@ -57,8 +58,10 @@ class _LoginScreenState extends State<LoginScreen> {
     if (args == 'reset-success') {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(content: Text('Passwort erfolgreich gesetzt.')),
+          showSuccessDialog(
+            context,
+            'Erfolg',
+            'Passwort erfolgreich gesetzt.',
           );
         }
       });
@@ -97,8 +100,10 @@ class _LoginScreenState extends State<LoginScreen> {
           }
 
           if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(content: Text("Erfolgreich eingeloggt als $email")),
+            showSuccessDialog(
+              context,
+              'Eingeloggt',
+              'Erfolgreich eingeloggt als $email',
             );
             _navigateToDashboard(context);
           }
@@ -108,9 +113,11 @@ class _LoginScreenState extends State<LoginScreen> {
               responseBody['error'] ??
               responseBody['message'] ??
               "Unbekannter Fehler";
-          ScaffoldMessenger.of(
+          showErrorDialog(
             context,
-          ).showSnackBar(SnackBar(content: Text("Fehler: $errorMsg")));
+            'Fehler',
+            'Fehler: $errorMsg',
+          );
           if (errorMsg.contains('E-Mail noch nicht bestätigt')) {
             setState(() {
               showResendButton = true;
@@ -122,10 +129,10 @@ class _LoginScreenState extends State<LoginScreen> {
 
         if (response.statusCode == 200) {
           if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(
-                content: Text('Registrierung erfolgreich. Bitte einloggen.'),
-              ),
+            showSuccessDialog(
+              context,
+              'Registriert',
+              'Registrierung erfolgreich. Bitte einloggen.',
             );
             setState(() {
               isLoginMode = true;
@@ -137,9 +144,11 @@ class _LoginScreenState extends State<LoginScreen> {
               responseBody['error'] ??
               responseBody['message'] ??
               "Unbekannter Fehler";
-          ScaffoldMessenger.of(
+          showErrorDialog(
             context,
-          ).showSnackBar(SnackBar(content: Text("Fehler: $errorMsg")));
+            'Fehler',
+            'Fehler: $errorMsg',
+          );
         }
       }
     } catch (e) {
@@ -147,9 +156,11 @@ class _LoginScreenState extends State<LoginScreen> {
       if (message.startsWith('Exception:')) {
         message = message.replaceFirst('Exception: ', '');
       }
-      ScaffoldMessenger.of(
+      showErrorDialog(
         context,
-      ).showSnackBar(SnackBar(content: Text(message.trim())));
+        'Fehler',
+        message.trim(),
+      );
       if (message.contains('E-Mail noch nicht bestätigt')) {
         setState(() {
           showResendButton = true;
@@ -191,16 +202,20 @@ class _LoginScreenState extends State<LoginScreen> {
     try {
       await AuthService.resendVerification(email);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(content: Text('Bestätigungs-E-Mail erneut gesendet.')),
+        showInfoDialog(
+          context,
+          'E-Mail gesendet',
+          'Bestätigungs-E-Mail erneut gesendet.',
         );
       }
       _startResendCooldown();
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(
+        showErrorDialog(
           context,
-        ).showSnackBar(SnackBar(content: Text('Fehler: $e')));
+          'Fehler',
+          'Fehler: $e',
+        );
       }
     }
   }
@@ -215,10 +230,10 @@ class _LoginScreenState extends State<LoginScreen> {
       ),
     );
     if (result == true && mounted) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text('E-Mail zum Zurücksetzen wurde gesendet.'),
-        ),
+      showInfoDialog(
+        context,
+        'E-Mail gesendet',
+        'E-Mail zum Zurücksetzen wurde gesendet.',
       );
     }
   }
@@ -280,10 +295,10 @@ class _LoginScreenState extends State<LoginScreen> {
                       if (!mounted) return;
                       _navigateToDashboard(context);
                     } catch (e) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('Google Anmeldung fehlgeschlagen: $e'),
-                        ),
+                      showErrorDialog(
+                        context,
+                        'Fehler',
+                        'Google Anmeldung fehlgeschlagen: $e',
                       );
                     }
                   },
@@ -313,10 +328,10 @@ class _LoginScreenState extends State<LoginScreen> {
                       await AuthService.signInWithGitHub(context);
                       // Navigation entfällt, Listener übernimmt das
                     } catch (e) {
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('GitHub Anmeldung fehlgeschlagen: $e'),
-                        ),
+                      showErrorDialog(
+                        context,
+                        'Fehler',
+                        'GitHub Anmeldung fehlgeschlagen: $e',
                       );
                     }
                   },

--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -61,7 +61,7 @@ class _LoginScreenState extends State<LoginScreen> {
           showSuccessDialog(
             context,
             'Erfolg',
-            'Passwort erfolgreich gesetzt.',
+            'Neues Passwort erfolgreich gesetzt.',
           );
         }
       });

--- a/lib/screens/reset_password_screen.dart
+++ b/lib/screens/reset_password_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../services/auth_service.dart';
 import '../utils/app_colors.dart';
+import '../utils/custom_dialog.dart';
 import 'login_screen.dart';
 
 class ResetPasswordScreen extends StatefulWidget {
@@ -63,9 +64,11 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
       }
     } catch (e) {
       if (mounted) {
-        ScaffoldMessenger.of(
+        showErrorDialog(
           context,
-        ).showSnackBar(SnackBar(content: Text('Fehler: $e')));
+          'Fehler',
+          'Fehler: $e',
+        );
       }
     } finally {
       if (mounted) setState(() => isLoading = false);

--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -9,6 +9,7 @@ import 'prompt_history_screen.dart';
 import '../services/user_service.dart';
 import '../utils/app_colors.dart';
 import '../utils/premium_required_dialog.dart';
+import '../utils/custom_dialog.dart';
 
 class TaskListScreen extends StatefulWidget {
   const TaskListScreen({super.key});
@@ -58,8 +59,10 @@ class _TaskListScreenState extends State<TaskListScreen> {
       await _loadTasks();
     } catch (e) {
       if (!mounted) return;
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('❌ $e')),
+      showErrorDialog(
+        context,
+        'Fehler',
+        '❌ $e',
       );
     } finally {
       if (mounted) {

--- a/lib/screens/task_screen.dart
+++ b/lib/screens/task_screen.dart
@@ -6,6 +6,7 @@ import '../services/ai_service.dart';
 import '../services/config.dart';
 import '../services/user_service.dart';
 import '../utils/premium_required_dialog.dart';
+import '../utils/custom_dialog.dart';
 import 'evaluation_screen.dart';
 import 'dart:convert';
 import 'package:http/http.dart' as http;
@@ -267,10 +268,10 @@ class _TaskScreenState extends State<TaskScreen> {
                                 ),
                               );
                             } else {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(
-                                  content: Text("Fehler bei der Bewertung"),
-                                ),
+                              showErrorDialog(
+                                context,
+                                'Fehler',
+                                'Fehler bei der Bewertung',
                               );
                             }
                           }

--- a/lib/utils/custom_dialog.dart
+++ b/lib/utils/custom_dialog.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'app_colors.dart';
+
+void showCustomDialog({
+  required BuildContext context,
+  required String title,
+  required String description,
+  required IconData icon,
+  required Color iconColor,
+  required String buttonText,
+}) {
+  showDialog(
+    context: context,
+    builder: (context) {
+      return Dialog(
+        backgroundColor: AppColors.primaryBackground,
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(20),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(icon, size: 60, color: iconColor),
+              const SizedBox(height: 16),
+              Text(
+                title,
+                style: TextStyle(
+                  fontSize: 22,
+                  fontWeight: FontWeight.bold,
+                  color: iconColor,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                description,
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  color: AppColors.white,
+                  fontSize: 16,
+                ),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context),
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: iconColor,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                child: Text(buttonText),
+              ),
+            ],
+          ),
+        ),
+      );
+    },
+  );
+}
+
+void showSuccessDialog(
+  BuildContext context,
+  String title,
+  String description, {
+  String buttonText = 'Okay',
+}) {
+  showCustomDialog(
+    context: context,
+    title: title,
+    description: description,
+    icon: Icons.check_circle_outline,
+    iconColor: Colors.green,
+    buttonText: buttonText,
+  );
+}
+
+void showErrorDialog(
+  BuildContext context,
+  String title,
+  String description, {
+  String buttonText = 'Schließen',
+}) {
+  showCustomDialog(
+    context: context,
+    title: title,
+    description: description,
+    icon: Icons.error_outline,
+    iconColor: Colors.red,
+    buttonText: buttonText,
+  );
+}
+
+void showInfoDialog(
+  BuildContext context,
+  String title,
+  String description, {
+  String buttonText = 'Okay',
+}) {
+  showCustomDialog(
+    context: context,
+    title: title,
+    description: description,
+    icon: Icons.info_outline,
+    iconColor: AppColors.accent,
+    buttonText: buttonText,
+  );
+}
+
+void showBadgeDialog(
+  BuildContext context,
+  String title,
+  String description, {
+  String buttonText = 'Cool!',
+}) {
+  showCustomDialog(
+    context: context,
+    title: title,
+    description: description,
+    icon: Icons.emoji_events,
+    iconColor: Colors.amber,
+    buttonText: buttonText,
+  );
+}


### PR DESCRIPTION
## Summary
- add a reusable `custom_dialog.dart` with helper functions
- replace SnackBars in Login, Reset Password, Task list, Task, and Evaluation screens with modal popups

## Testing
- `flutter analyze` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863b534f8108320bc10f70c41d34792