### PR TITLE
Ensure reset success dialog only shows once

### DIFF
--- a/lib/screens/login_screen.dart
+++ b/lib/screens/login_screen.dart
@@ -26,6 +26,7 @@ class _LoginScreenState extends State<LoginScreen> {
   bool showResendButton = false;
   int resendCooldown = 0;
   Timer? resendTimer;
+  bool _resetDialogShown = false;
 
   bool isEmailValid(String email) {
     return EmailValidator.validate(email);
@@ -55,9 +56,10 @@ class _LoginScreenState extends State<LoginScreen> {
   void didChangeDependencies() {
     super.didChangeDependencies();
     final args = ModalRoute.of(context)?.settings.arguments;
-    if (args == 'reset-success') {
+    if (!_resetDialogShown && args == 'reset-success') {
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted) {
+          _resetDialogShown = true;
           showSuccessDialog(
             context,
             'Erfolg',


### PR DESCRIPTION
## Summary
- add `_resetDialogShown` field on `_LoginScreenState`
- mark the reset dialog as shown before displaying it

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863d28539f0832097c62da669b48dc6